### PR TITLE
exit grain process if 'save' returned with no provider

### DIFF
--- a/test/grain_lifecycle_SUITE.erl
+++ b/test/grain_lifecycle_SUITE.erl
@@ -15,7 +15,7 @@
 -include("test_utils.hrl").
 
 all() ->
-    [manual_start_stop, bad_etag_save, ephemeral_state].
+    [manual_start_stop, bad_etag_save, ephemeral_state, no_provider_grain].
 
 init_per_suite(Config) ->
     application:ensure_all_started(pgsql),
@@ -94,5 +94,16 @@ ephemeral_state(_Config) ->
     ?assertMatch({ok, N} when N > 1, test_ephemeral_state_grain:activated_counter(Grain)),
     %% But ephemeral counter should be 0 again
     ?assertEqual({ok, 0}, test_ephemeral_state_grain:ephemeral_counter(Grain)),
+
+    ok.
+
+no_provider_grain(_Config) ->
+    application:set_env(erleans, default_lease_time, 60),
+    Grain = erleans:get_grain(no_provider_test_grain, <<"no_provider">>),
+
+    ?assertEqual(hello, no_provider_test_grain:hello(Grain)),
+
+    %% attempt to save state through erleans_grain without a provider configured
+    ?assertExit({no_provider_configured, _}, no_provider_test_grain:save(Grain)),
 
     ok.

--- a/test/no_provider_test_grain.erl
+++ b/test/no_provider_test_grain.erl
@@ -1,0 +1,53 @@
+%%% ---------------------------------------------------------------------------
+%%% @author Tristan Sloughter <tristan.sloughter@spacetimeinsight.com>
+%%% @copyright 2016 Space-Time Insight <tristan.sloughter@spacetimeinsight.com>
+%%%
+%%% @doc A grain that doesn't use any storage provider.
+%%% @end
+%%% ---------------------------------------------------------------------------
+-module(no_provider_test_grain).
+
+-behaviour(erleans_grain).
+
+-export([placement/0,
+         hello/1,
+         save/1]).
+
+-export([init/2,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         deactivate/1]).
+
+-include("erleans.hrl").
+
+placement() ->
+    prefer_local.
+
+hello(Ref) ->
+    erleans_grain:call(Ref, hello).
+
+save(Ref) ->
+    erleans_grain:call(Ref, save).
+
+init(_, State) ->
+    {ok, State, #{}}.
+
+handle_call(hello, _From, State) ->
+    {reply, hello, State};
+handle_call(save, _From, State) ->
+    %% will throw an exception
+    {save_reply, ok, State}.
+
+handle_cast(_, State) ->
+    {noreply, State}.
+
+handle_info(_, State) ->
+    {noreply, State}.
+
+deactivate(State) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================


### PR DESCRIPTION
Resolves #12 

A grain is not required to have a storage provider. If it wants to use the default provider it must return `default_provider` from the callback. Otherwise it is assumed it does not want to persist state through `erleans_grain` and either has no state it wants to save or will do it on its own.