### PR TITLE
Convert to using gen_statem for grain process

### DIFF
--- a/test/grain_lifecycle_SUITE.erl
+++ b/test/grain_lifecycle_SUITE.erl
@@ -156,6 +156,7 @@ request_types(_Config) ->
 
     _Pinger =
         spawn(fun () ->
+                      put(req_type, leave_timer),
                       [begin
                            timer:sleep(6),
                            Ct = (catch test_grain:activated_counter(GrainPid)),


### PR DESCRIPTION
Using the statem behaviour simplifies some logic for the grain implementation, such as deactivation timer can now be done as a `state_timeout` and no need to track `deactivating` as a boolean in the state, instead use a state in the state machine.