### PR TITLE
New grain interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,12 @@ activated_counter(Ref) ->
 node(Ref) ->
     erleans_grain:call(Ref, node).
 
-activate(_Grainref, State=#{activated_counter := Counter}) ->
-    {ok, State#{activated_counter => Counter+1}, #{}};
-activate(_Grainref, State=#{}) ->
-    {ok, State#{activated_counter => 1}, #{}}.
+state(_) ->
+    #{activated_counter => 0,
+      deactivated_counter => 0}.
+
+activate(_, State=#{activated_counter := Counter}) ->
+    {ok, State#{activated_counter => Counter+1}, #{}}.
 ```
 
 ```erlang

--- a/src/erleans.erl
+++ b/src/erleans.erl
@@ -76,7 +76,7 @@ get_stream(StreamProvider, Topic, FetchInterval) ->
 
 -spec provider(module()) -> provider().
 provider(CbModule) ->
-    case fun_or_default(CbModule, provider, undefined) of
+    case erleans_utils:fun_or_default(CbModule, provider, undefined) of
         undefined ->
             undefined;
         Name ->
@@ -103,22 +103,9 @@ find_provider_config(Name) ->
 
 -spec placement(module()) -> placement().
 placement(Module) ->
-    case fun_or_default(Module, placement, ?DEFAULT_PLACEMENT) of
+    case erleans_utils:fun_or_default(Module, placement, ?DEFAULT_PLACEMENT) of
         stateless ->
             {stateless, erleans_config:get(default_stateless_max, 5)};
         Placement ->
             Placement
-    end.
-
-%% If a function is exported by the module return the result of calling it
-%% else return the default.
--spec fun_or_default(module(), atom(), term()) -> term().
-fun_or_default(Module, FunctionName, Default) ->
-    %% load the module if it isn't already
-    erlang:function_exported(Module, module_info, 0) orelse code:ensure_loaded(Module),
-    case erlang:function_exported(Module, FunctionName, 0) of
-        true ->
-            Module:FunctionName();
-        false ->
-            Default
     end.

--- a/src/erleans_pgsql_blob_provider.erl
+++ b/src/erleans_pgsql_blob_provider.erl
@@ -32,8 +32,8 @@
          read_by_hash/3,
          insert/5,
          insert/6,
-         replace/6,
-         replace/7]).
+         update/6,
+         update/7]).
 
 -include("erleans.hrl").
 
@@ -84,11 +84,11 @@ insert(Type, ProviderName, Id, State, ETag) ->
 insert(Type, ProviderName, Id, Hash, State, ETag) ->
     do(ProviderName, fun(C) -> insert_(Id, Type, Hash, ETag, State, C) end).
 
-replace(Type, ProviderName, Id, State, OldETag, NewETag) ->
-    replace(Type, ProviderName, Id, erlang:phash2({Id, Type}), State, OldETag, NewETag).
+update(Type, ProviderName, Id, State, OldETag, NewETag) ->
+    update(Type, ProviderName, Id, erlang:phash2({Id, Type}), State, OldETag, NewETag).
 
-replace(Type, ProviderName, Id, Hash, State, OldETag, NewETag) ->
-    do(ProviderName, fun(C) -> replace_(Id, Type, Hash, OldETag, NewETag, State, C) end).
+update(Type, ProviderName, Id, Hash, State, OldETag, NewETag) ->
+    do(ProviderName, fun(C) -> update_(Id, Type, Hash, OldETag, NewETag, State, C) end).
 
 %%%
 
@@ -149,7 +149,7 @@ insert_(Id, Type, RefHash, GrainETag, GrainState, C) ->
                                                                GrainETag, term_to_binary(GrainState)],
                                                            {pgsql_connection, C}).
 
-replace_(Id, Type, RefHash, OldGrainETag, NewGrainETag, GrainState, C) ->
+update_(Id, Type, RefHash, OldGrainETag, NewGrainETag, GrainState, C) ->
     Q = query(update),
     IdBin = term_to_binary(Id),
     case pgsql_connection:extended_query(Q, [NewGrainETag, term_to_binary(GrainState), RefHash, IdBin,

--- a/src/erleans_provider.erl
+++ b/src/erleans_provider.erl
@@ -39,22 +39,13 @@
 -callback insert(Type :: module(), ProviderName :: atom(), Id :: any(), Hash :: integer(),
                  State :: any(), ETag :: erleans:etag()) -> ok.
 
--callback update(Type :: module(), ProviderName :: atom(), Id :: any(), Update :: list(),
-                 ETag :: erleans:etag(), NewETag :: erleans:etag()) ->
-    ok |
-    {error, {bad_etag, erleans:etag(), erleans:etag()}} |
-    {error, not_found}.
-
-%% Not all backends are going to be able to provide per-field update functionality
--optional_callbacks([update/6]).
-
--callback replace(Type :: module(), ProviderName :: atom(), Id :: any(), State :: any(),
+-callback update(Type :: module(), ProviderName :: atom(), Id :: any(), State :: any(),
                   ETag :: erleans:etag(), NewETag :: erleans:etag()) ->
     ok |
     {error, {bad_etag, erleans:etag(), erleans:etag()}} |
     {error, not_found}.
 
--callback replace(Type :: module(), ProviderName :: atom(), Id :: any(), Hash :: integer(),
+-callback update(Type :: module(), ProviderName :: atom(), Id :: any(), Hash :: integer(),
                   State :: any(), ETag :: erleans:etag(), NewETag :: erleans:etag()) ->
     ok |
     {error, {bad_etag, erleans:etag(), erleans:etag()}} |

--- a/src/erleans_stream_manager.erl
+++ b/src/erleans_stream_manager.erl
@@ -317,7 +317,7 @@ save(Id, Partition, Value, undefined, {ProviderModule, ProviderName}) ->
     ETag;
 save(Id, Partition, Value, OldETag, {ProviderModule, ProviderName}) ->
     ETag = erlang:phash2(Value),
-    ProviderModule:replace(erleans_stream, ProviderName, Id, Partition, Value, OldETag, ETag),
+    ProviderModule:update(erleans_stream, ProviderName, Id, Partition, Value, OldETag, ETag),
     ETag.
 
 delete(Id, {ProviderModule, ProviderName}) ->

--- a/src/erleans_utils.erl
+++ b/src/erleans_utils.erl
@@ -1,0 +1,41 @@
+%%%--------------------------------------------------------------------
+%%% Copyright Space-Time Insight 2017. All Rights Reserved.
+%%%
+%%% Licensed under the Apache License, Version 2.0 (the "License");
+%%% you may not use this file except in compliance with the License.
+%%% You may obtain a copy of the License at
+%%%
+%%%     http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing, software
+%%% distributed under the License is distributed on an "AS IS" BASIS,
+%%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%% See the License for the specific language governing permissions and
+%%% limitations under the License.
+%%%-----------------------------------------------------------------
+
+%%% ---------------------------------------------------------------------------
+%%% @doc
+%%% @end
+%%% ---------------------------------------------------------------------------
+-module(erleans_utils).
+
+-export([fun_or_default/3]).
+-export([fun_or_default/5]).
+
+%% If a function is exported by the module return the result of calling it
+%% else return the default.
+-spec fun_or_default(module(), atom(), term()) -> term().
+fun_or_default(Module, FunctionName, Default) ->
+    fun_or_default(Module, FunctionName, 0, [], Default).
+
+-spec fun_or_default(module(), atom(), integer(), list(), term()) -> term().
+fun_or_default(Module, FunctionName, Arity, Args, Default) ->
+    %% load the module if it isn't already
+    erlang:function_exported(Module, module_info, 0) orelse code:ensure_loaded(Module),
+    case erlang:function_exported(Module, FunctionName, Arity) of
+        true ->
+            erlang:apply(Module, FunctionName, Args);
+        false ->
+            Default
+    end.

--- a/test/ets_provider.erl
+++ b/test/ets_provider.erl
@@ -9,8 +9,8 @@
          read_by_hash/3,
          insert/5,
          insert/6,
-         replace/6,
-         replace/7,
+         update/6,
+         update/7,
          delete/3]).
 
 -define(TAB, ets_provider_tab).
@@ -49,10 +49,10 @@ insert(Type, _ProviderName, Id, Hash, State, ETag) ->
     true = ets:insert(?TAB, {Id, Type, Hash, ETag, State}),
     ok.
 
-replace(Type, ProviderName, Id, State, ETag, NewETag) ->
-    replace(Type, ProviderName, Id, erlang:phash2({Id, Type}), State, ETag, NewETag).
+update(Type, ProviderName, Id, State, ETag, NewETag) ->
+    update(Type, ProviderName, Id, erlang:phash2({Id, Type}), State, ETag, NewETag).
 
-replace(Type, _ProviderName, Id, Hash, State, ETag, NewETag) ->
+update(Type, _ProviderName, Id, Hash, State, ETag, NewETag) ->
     case ets:lookup(?TAB, Id) of
         [{Id, Type, _, E, _}] when E =:= ETag ->
             true = ets:insert(?TAB, {Id, Type, Hash, NewETag, State}),

--- a/test/grain_lifecycle_SUITE.erl
+++ b/test/grain_lifecycle_SUITE.erl
@@ -15,8 +15,8 @@
 -include("test_utils.hrl").
 
 all() ->
-    [manual_start_stop, bad_etag_save, ephemeral_state, no_provider_grain,
-     request_types].
+    [manual_start_stop, bad_etag_save, ephemeral_state,
+     no_provider_grain, request_types].
 
 init_per_suite(Config) ->
     application:ensure_all_started(pgsql),
@@ -63,10 +63,10 @@ bad_etag_save(_Config) ->
 
     ?assertEqual({ok, 1}, test_grain:activated_counter(Grain)),
 
-    OldETag = erlang:phash2(#{activated_counter => 1}),
+    OldETag = erlang:phash2(#{activated_counter => 1, deactivated_counter => 0}),
     NewState = #{activated_counter => 2, deactivated_counter => 0},
     NewETag = erlang:phash2(NewState),
-    ProviderModule:replace(test_grain, ProviderName, <<"bad-etag-save-grain">>, NewState, OldETag, NewETag),
+    ok = ProviderModule:replace(test_grain, ProviderName, <<"bad-etag-save-grain">>, NewState, OldETag, NewETag),
 
     %% Now a save call should crash the grain
     ?assertMatch({exit, saved_etag_changed}, test_grain:save(Grain)),

--- a/test/grain_lifecycle_SUITE.erl
+++ b/test/grain_lifecycle_SUITE.erl
@@ -66,7 +66,7 @@ bad_etag_save(_Config) ->
     OldETag = erlang:phash2(#{activated_counter => 1, deactivated_counter => 0}),
     NewState = #{activated_counter => 2, deactivated_counter => 0},
     NewETag = erlang:phash2(NewState),
-    ok = ProviderModule:replace(test_grain, ProviderName, <<"bad-etag-save-grain">>, NewState, OldETag, NewETag),
+    ok = ProviderModule:update(test_grain, ProviderName, <<"bad-etag-save-grain">>, NewState, OldETag, NewETag),
 
     %% Now a save call should crash the grain
     ?assertMatch({exit, saved_etag_changed}, test_grain:save(Grain)),

--- a/test/no_provider_test_grain.erl
+++ b/test/no_provider_test_grain.erl
@@ -16,7 +16,6 @@
 -export([activate/2,
          handle_call/3,
          handle_cast/2,
-         handle_info/2,
          deactivate/1]).
 
 -include("erleans.hrl").
@@ -33,17 +32,14 @@ save(Ref) ->
 activate(_, State) ->
     {ok, State, #{}}.
 
-handle_call(hello, _From, State) ->
-    {reply, hello, State};
-handle_call(save, _From, State) ->
+handle_call(hello, From, State) ->
+    {ok, State, [{reply, From, hello}]};
+handle_call(save, From, State) ->
     %% will throw an exception
-    {save_reply, ok, State}.
+    {ok, State, [{reply, From, ok}, save_state]}.
 
 handle_cast(_, State) ->
-    {noreply, State}.
-
-handle_info(_, State) ->
-    {noreply, State}.
+    {ok, State}.
 
 deactivate(State) ->
     {ok, State}.

--- a/test/test_grain.erl
+++ b/test/test_grain.erl
@@ -16,10 +16,10 @@
          deactivated_counter/1,
          activated_counter/1]).
 
--export([activate/2,
+-export([state/1,
+         activate/2,
          handle_call/3,
          handle_cast/2,
-         handle_info/2,
          deactivate/1]).
 
 -include("erleans.hrl").
@@ -42,34 +42,31 @@ save(Ref) ->
 node(Ref) ->
     erleans_grain:call(Ref, node).
 
-activate(_, State=#{activated_counter := Counter}) ->
-    {ok, State#{activated_counter => Counter+1}, #{}};
-activate(_, State=#{}) ->
-    {ok, State#{activated_counter => 1}, #{}}.
+state(_) ->
+    #{activated_counter => 0,
+      deactivated_counter => 0}.
 
-handle_call(node, _From, State) ->
-    {reply, {ok, node()}, State};
-handle_call(deactivated_counter, _From, State=#{deactivated_counter := Counter}) ->
-    {reply, {ok, Counter}, State};
-handle_call(deactivated_counter, _From, State) ->
-    {reply, {ok, 0}, State};
-handle_call(activated_counter, _From, State=#{activated_counter := Counter}) ->
-    {reply, {ok, Counter}, State};
-handle_call(activated_counter, _From, State) ->
-    {reply, {ok, 0}, State};
-handle_call(save, _From, State) ->
-    {save_reply, ok, State}.
+activate(_, State=#{activated_counter := Counter}) ->
+    {ok, State#{activated_counter => Counter+1}, #{}}.
+
+handle_call(node, From, State) ->
+    {ok, State, [{reply, From, {ok, node()}}]};
+handle_call(deactivated_counter, From, State=#{deactivated_counter := Counter}) ->
+    {ok, State, [{reply, From, {ok, Counter}}]};
+handle_call(deactivated_counter, From, State) ->
+    {ok, State, [{reply, From, {ok, 0}}]};
+handle_call(activated_counter, From, State=#{activated_counter := Counter}) ->
+    {ok, State, [{reply, From, {ok, Counter}}]};
+handle_call(activated_counter, From, State) ->
+    {ok, State, [{reply, From, {ok, 0}}]};
+handle_call(save, From, State) ->
+    {ok, State, [{reply, From, ok}, save_state]}.
 
 handle_cast(_, State) ->
-    {noreply, State}.
-
-handle_info(_, State) ->
-    {noreply, State}.
+    {ok, State}.
 
 deactivate(State=#{deactivated_counter := D}) ->
-    {save, State#{deactivated_counter => D+1}};
-deactivate(State) ->
-    {save, State#{deactivated_counter => 1}}.
+    {save_state, State#{deactivated_counter => D+1}}.
 
 %%%===================================================================
 %%% Internal functions


### PR DESCRIPTION
The grain behaviour works on actions return from the callbacks similar to gen_statem. These actions can send a reply, save the persistent state or enqueue the next cast/info callback to handle.

The separation of persistent vs ephemeral state is simply a tuple. If the State returned by the grain is a 2-tuple then it considers the second element as the persistent state in the case of a `save_state` being one of the actions.

Also, update makes more sense than replace because it will return an error if the etags do not match, meaning it is not really a replace but an update. So this patch removes `replace` and uses just `update` for providers.