### PR TITLE
proc_lib start and instrument requests to grains with opencensus

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -17,6 +17,7 @@
         jch,
         eql,
         {vonnegut, {git, "https://github.com/spacetime-iot/vonnegut.git", {branch, "master"}}},
+        {opencensus, {git, "https://github.com/census-instrumentation/opencensus-erlang.git", {branch, "master"}}},
         {uuid, {pkg, uuid_erl}}]}.
 
 {profiles, [{db, [{deps, [pgsql]},

--- a/rebar.lock
+++ b/rebar.lock
@@ -17,11 +17,16 @@
  {<<"lasp_pg">>,{pkg,<<"lasp_pg">>,<<"0.0.1">>},0},
  {<<"lasp_support">>,{pkg,<<"lasp_support">>,<<"0.0.3">>},1},
  {<<"metal">>,{pkg,<<"metal">>,<<"0.1.0">>},2},
+ {<<"opencensus">>,
+  {git,"https://github.com/census-instrumentation/opencensus-erlang.git",
+       {ref,"b8fecf303896a9bdbfe9d1f83371a5bc1e88a28a"}},
+  0},
  {<<"partisan">>,{pkg,<<"partisan">>,<<"1.0.1">>},0},
  {<<"plumtree">>,{pkg,<<"plumtree">>,<<"0.4.0">>},1},
  {<<"prometheus">>,{pkg,<<"prometheus">>,<<"3.4.0">>},1},
  {<<"quickrand">>,{pkg,<<"quickrand">>,<<"1.7.2">>},1},
  {<<"rand_compat">>,{pkg,<<"rand_compat">>,<<"0.0.3">>},1},
+ {<<"rfc3339">>,{pkg,<<"rfc3339">>,<<"0.9.0">>},2},
  {<<"sbroker">>,{pkg,<<"sbroker">>,<<"1.0.0">>},0},
  {<<"sext">>,{pkg,<<"sext">>,<<"1.4.0">>},1},
  {<<"shackle">>,{pkg,<<"shackle">>,<<"0.5.1">>},1},
@@ -31,7 +36,8 @@
  {<<"vonnegut">>,
   {git,"https://github.com/spacetime-iot/vonnegut.git",
        {ref,"7d0d9123830215fa75f7fe18033aa9f7f500639b"}},
-  0}]}.
+  0},
+ {<<"wts">>,{pkg,<<"wts">>,<<"0.3.0">>},1}]}.
 [
 {pkg_hash,[
  {<<"accept">>, <<"2505B60BCB992CA79BD03AB7B8FEC8A520A47D9730F286DF1A479CC98B03F94B">>},
@@ -57,10 +63,12 @@
  {<<"prometheus">>, <<"91759726F2E384DF2EF48DAF039D506705A7AA81DCBBB2DBFFEE1FD0C5431D32">>},
  {<<"quickrand">>, <<"E856F3C69FEC00D1ACCA8E56CB452B650E838D3A9720811410F439121EFAFE59">>},
  {<<"rand_compat">>, <<"011646BC1F0B0C432FE101B816F25B9BBB74A085713CEE1DAFD2D62E9415EAD3">>},
+ {<<"rfc3339">>, <<"2075653DC9407541C84B1E15F8BDA2ABE95FB17C9694025E079583F2D19C1060">>},
  {<<"sbroker">>, <<"28FF1B5E58887C5098539F236307B36FE1D3EDAA2ACFF9D6A3D17C2DCAFEBBD0">>},
  {<<"sext">>, <<"2A9443A90C3164231A5E11C73133C4B1762B27FBF1647AA0DE06EF565C47B38B">>},
  {<<"shackle">>, <<"D32906B49BDF030127558778F2E5CEE9D7F10C55DD40E25DA51381EADA719CBF">>},
  {<<"time_compat">>, <<"23FE0AD1FDF3B5B88821B2D04B4B5E865BF587AE66056D671FE0F53514ED8139">>},
  {<<"types">>, <<"03BB7140016C896D3441A77CB0B7D6ACAA583D6D6E9C4A3E1FD3C25123710290">>},
- {<<"uuid">>, <<"D596C8DD01A4AE48B9D8D51832CCC8F8302BF67ACD01336AEC3FCFAE6B9D2BC2">>}]}
+ {<<"uuid">>, <<"D596C8DD01A4AE48B9D8D51832CCC8F8302BF67ACD01336AEC3FCFAE6B9D2BC2">>},
+ {<<"wts">>, <<"5CDF22C775CB1EBAE24C326A5DB6074D753C42F4BD12A9AA47CC62D3E2C71AD1">>}]}
 ].

--- a/src/erleans.app.src
+++ b/src/erleans.app.src
@@ -16,7 +16,8 @@
     jch,
     eql,
     erlware_commons,
-    vonnegut
+    vonnegut,
+    opencensus
    ]},
   {modules, []},
   {env, [{deactivate_after, 2700000}, %% 45 minutes

--- a/src/erleans_grain.erl
+++ b/src/erleans_grain.erl
@@ -40,6 +40,7 @@
          unsubscribe/2]).
 
 -export([init/1,
+         init/2,
          callback_mode/0,
          active/3,
          deactivating/3,
@@ -110,13 +111,8 @@
 -export_types([opts/0]).
 
 -spec start_link(GrainRef :: erleans:grain_ref()) -> {ok, pid() | undefined} | {error, any()}.
-start_link(GrainRef = #{placement := {stateless, _N}}) ->
-    {ok, Pid} = gen_statem:start_link(?MODULE, [GrainRef], []),
-    gproc:reg(?stateless_counter(GrainRef)),
-    gproc:reg_other(?stateless(GrainRef), Pid),
-    {ok, Pid};
 start_link(GrainRef) ->
-    gen_statem:start_link({via, erleans_pm, GrainRef}, ?MODULE, [GrainRef], []).
+    proc_lib:start_link(?MODULE, init, [self(), GrainRef]).
 
 subscribe(StreamProvider, Topic) ->
     %% 0 is going to be the most common initial token, but subscribe/3
@@ -154,7 +150,7 @@ call(GrainRef, Request, Timeout) ->
 -spec cast(GrainRef :: erleans:grain_ref(), Request :: term()) -> Reply :: term().
 cast(GrainRef, Request) ->
     ReqType = req_type(),
-    do_for_ref(GrainRef, fun(Pid) -> gen_statem:cast(Pid, {ReqType, Request}) end).
+    do_for_ref(GrainRef, fun(Pid) -> gen_statem:cast(Pid, {ocp:context(), ReqType, Request}) end).
 
 req_type() ->
     case get(req_type) of
@@ -231,10 +227,22 @@ activate_random(GrainRef) ->
     Node = lists:nth(Nth, Members),
     erleans_grain_sup:start_child(Node, GrainRef).
 
-init([GrainRef=#{id := Id,
-                 implementing_module := CbModule}]) ->
+%% not used but required by the behaviour definition
+init(Args) -> erlang:error(not_implemented, [Args]).
+
+init(Parent, GrainRef=#{id := Id,
+                        implementing_module := CbModule}) ->
     put(grain_ref, GrainRef),
     process_flag(trap_exit, true),
+
+    case GrainRef of
+        #{placement := {stateless, _N}} ->
+            gproc:reg(?stateless_counter(GrainRef)),
+            gproc:reg_other(?stateless(GrainRef), self());
+        _->
+            erleans_pm:register_name(GrainRef, self())
+    end,
+
     {CbData, ETag} = case maps:find(provider, GrainRef) of
                           {ok, Provider={ProviderModule, ProviderName}} ->
                               case ProviderModule:read(CbModule, ProviderName, Id) of
@@ -255,18 +263,18 @@ init([GrainRef=#{id := Id,
 
     case CbData of
         notfound ->
-            ignore;
+            exit(notfound);
         _ ->
             case erleans_utils:fun_or_default(CbModule, activate, 2, [GrainRef, CbData], {ok, CbData, #{}}) of
                 {ok, CbData1, GrainOpts} ->
-                    init_(GrainRef, CbModule, Id, Provider, ETag, GrainOpts, CbData1);
+                    init_(Parent, GrainRef, CbModule, Id, Provider, ETag, GrainOpts, CbData1);
                 {error, notfound} ->
                     %% activate returning {error, notfound} is given special treatment and
                     %% results in an ignore from the statem and an `exit({noproc, notfound})`
                     %% from `erleans_grain`
-                    ignore;
+                    exit(notfound);
                 {error, Reason} ->
-                    {stop, Reason}
+                    exit(Reason)
             end
     end.
 
@@ -278,7 +286,7 @@ new_state(CbModule, Id) ->
             {#{}, undefined}
     end.
 
-init_(GrainRef, CbModule, Id, Provider, ETag, GrainOpts, CbData1) ->
+init_(Parent, GrainRef, CbModule, Id, Provider, ETag, GrainOpts, CbData1) ->
     {CbData2, ETag1} = verify_etag(CbModule, Id, Provider, ETag, CbData1),
     CreateTime = maps:get(create_time, GrainOpts, erlang:system_time(seconds)),
     DeactivateAfter = maps:get(deactivate_after, GrainOpts, erleans_config:get(deactivate_after)),
@@ -292,7 +300,8 @@ init_(GrainRef, CbModule, Id, Provider, ETag, GrainOpts, CbData1) ->
                  create_time      = CreateTime,
                  deactivate_after = case DeactivateAfter of 0 -> infinity; _ -> DeactivateAfter end
                 },
-    {ok, active, Data}.
+    proc_lib:init_ack(Parent, {ok, self()}),
+    gen_statem:enter_loop(?MODULE, [], active, Data).
 
 callback_mode() ->
     [state_functions, state_enter].
@@ -300,8 +309,8 @@ callback_mode() ->
 active(enter, _OldState, Data=#data{deactivate_after=DeactivateAfter}) ->
     {keep_state, Data, [{state_timeout, DeactivateAfter, activation_expiry}]};
 active({call, From}, {undefined, ReqType, Msg}, Data=#data{cb_module=CbModule,
-                                                cb_state=CbData,
-                                                deactivate_after=DeactivateAfter}) ->
+                                                           cb_state=CbData,
+                                                           deactivate_after=DeactivateAfter}) ->
     handle_result(CbModule:handle_call(Msg, From, CbData), Data, upd_timer(ReqType, DeactivateAfter));
 active({call, From}, {TraceContext, ReqType, Msg}, Data=#data{cb_module=CbModule,
                                                               cb_state=CbData,
@@ -309,13 +318,24 @@ active({call, From}, {TraceContext, ReqType, Msg}, Data=#data{cb_module=CbModule
     ocp:start_trace(TraceContext),
     ocp:start_span(span_name(Msg)),
     ocp:put_attribute(<<"grain_msg">>, io_lib:format("~p", [Msg])),
-    Result = handle_result(CbModule:handle_call(Msg, From, CbData), Data, upd_timer(ReqType, DeactivateAfter)),
-    ocp:finish_span(),
-    Result;
-active(cast, {ReqType, Msg}, Data=#data{cb_module=CbModule,
-                                        cb_state=CbData,
-                                        deactivate_after=DeactivateAfter}) ->
+    try handle_result(CbModule:handle_call(Msg, From, CbData), Data, upd_timer(ReqType, DeactivateAfter))
+    after
+        ocp:finish_span()
+    end;
+active(cast, {undefined, ReqType, Msg}, Data=#data{cb_module=CbModule,
+                                                   cb_state=CbData,
+                                                   deactivate_after=DeactivateAfter}) ->
     handle_result(CbModule:handle_cast(Msg, CbData), Data, upd_timer(ReqType, DeactivateAfter));
+active(cast, {TraceContext, ReqType, Msg}, Data=#data{cb_module=CbModule,
+                                                      cb_state=CbData,
+                                                      deactivate_after=DeactivateAfter}) ->
+    ocp:start_trace(TraceContext),
+    ocp:start_span(span_name(Msg)),
+    ocp:put_attribute(<<"grain_msg">>, io_lib:format("~p", [Msg])),
+    try handle_result(CbModule:handle_cast(Msg, CbData), Data, upd_timer(ReqType, DeactivateAfter))
+    after
+        ocp:finish_span()
+    end;
 active(state_timeout, activation_expiry, Data) ->
     {next_state, deactivating, Data};
 active(EventType, Event, Data) ->


### PR DESCRIPTION
Opening for feedback.

In the current state it will only trace grain `calls` and only if the a trace was already started (if `ocp:trace_context` returns `undefined` there won't be a span created in `activate`).

I was most interested in doing this for calls, but I guess no reason to not also do the same for casts?