### PR TITLE
block partitions initialization on erleans_discovery finishing start

### DIFF
--- a/src/erleans_partitions.erl
+++ b/src/erleans_partitions.erl
@@ -109,7 +109,8 @@ handle_info({update, Membership}, State=#state{num_partitions=NumPartitions,
                           node_ranges=NodeRanges}};
 handle_info(timeout, State=#state{num_partitions=NumPartitions,
                                   to_notify=ToNotify}) ->
-    {ok, MembersList} = partisan_peer_service:members(),
+    %% blocks until the discovery process has initalized fully
+    {ok, MembersList} = erleans_discovery:members(),
     {Range, NodeRanges} = update_ranges(MembersList, NumPartitions, ToNotify),
     {noreply, State#state{range=Range,
                           node_ranges=NodeRanges}};


### PR DESCRIPTION
This should keep partitions management from crashing by having it wait on the discovery process to finish its update of the partisan membership.